### PR TITLE
Do not double sum the histogram of absolute gradients

### DIFF
--- a/Modules/Features/AutomaticConductanceImageCalculator/itkAutomaticConductanceImageCalculator.hxx
+++ b/Modules/Features/AutomaticConductanceImageCalculator/itkAutomaticConductanceImageCalculator.hxx
@@ -116,15 +116,15 @@ AutomaticConductanceImageCalculator< TInputImage >
 
     typename ImageToHistogramFilterType::HistogramType* histogramG = gradToHist->GetOutput();
 
-    double cumulativeSum = 0.0, total = 0.0, percentage = 0.0;
+    double cumulativeSum = 0.0, total = 0.0;
     for (int idx = 0; idx < histogramG->GetSize()[0]; ++idx) {
         total+=histogramG->GetFrequency(idx);
     }
 
     for (int idx = 0; idx < histogramG->GetSize()[0]; ++idx) {
         cumulativeSum+=histogramG->GetFrequency(idx);
-        percentage += cumulativeSum/total;
-        if (percentage > 0.9) {
+        double percentage = cumulativeSum/total;
+        if (percentage >= 0.9) {
             m_Kappa = static_cast<PixelType>(histogramG->GetBinMinFromValue(0,histogramG->GetMeasurement(idx,0)));
             break;
         }


### PR DESCRIPTION
Reposting email to me:

>I based this implementation on the comment made by Perona and Malik (1) regarding the Kappa estimation. Please, see the page 5 at the bottom. 
If I did not make any mistake, the K calculation is first based on the integral of the absolute gradient histogram (which may be interpreted as a cumulative sum), and then check if this integral reaches to 90% level (Am I right?)
Indeed, that line that you highlighted is weird... I am thinking of changing it as you commented.

>(1) Perona, P., & Malik, J. (1990). Scale-space and edge detection using anisotropic diffusion. IEEE Transactions on Pattern Analysis and Machine Intelligence, 12(7), 629–639. https://doi.org/10.1109/34.56205